### PR TITLE
Improve RUT validation and normalization

### DIFF
--- a/cuenta01.php
+++ b/cuenta01.php
@@ -1,8 +1,9 @@
 <?php
 include 'db.php';  // tu conexión
+require_once 'includes/rut_validator.php';
 
 // Datos del nuevo usuario
-$rut      = '24471968-6';
+$rut      = limpiar_rut('24471968-6');
 $pass     = '1234';
 $hash     = password_hash($pass, PASSWORD_DEFAULT);
 $nombre   = 'Nickens';

--- a/includes/auth.php
+++ b/includes/auth.php
@@ -8,6 +8,7 @@ require_once __DIR__ . '/rut_validator.php';
  * Intenta autenticar al usuario.
  */
 function login(string $rut, string $clave): bool {
+    $rut = limpiar_rut($rut);
     if (!validar_rut($rut)) {
         return false;
     }

--- a/includes/rut_validator.php
+++ b/includes/rut_validator.php
@@ -2,13 +2,33 @@
 // includes/rut_validator.php
 
 /**
- * Valida RUT chileno (sin puntos, con guión y dígito verificador).
- * Ej: 12345678-5
+ * Elimina puntos, guiones u otros caracteres y devuelve el RUT en
+ * mayúsculas. Útil para almacenar el valor siempre con el mismo
+ * formato. Ej: "12.345.678-k" → "12345678K".
+ */
+function limpiar_rut(string $rut): string {
+    return strtoupper(preg_replace('/[^0-9kK]/', '', $rut));
+}
+
+/**
+ * Devuelve el RUT formateado con puntos y guión.
+ */
+function formatear_rut(string $rut): string {
+    $rut = limpiar_rut($rut);
+    if (strlen($rut) < 2) return $rut;
+    $num = substr($rut, 0, -1);
+    $dv  = substr($rut, -1);
+    $num = number_format(intval($num), 0, '', '.');
+    return $num . '-' . $dv;
+}
+
+/**
+ * Valida un RUT chileno (con o sin puntos o guión).
  */
 function validar_rut(string $rut): bool {
-    $rut = preg_replace('/[^\\dkK]/', '', $rut);
+    $rut = limpiar_rut($rut);
     if (strlen($rut) < 2) return false;
-    $dv = strtoupper(substr($rut, -1));
+    $dv = substr($rut, -1);
     $num = substr($rut, 0, -1);
     $reversed = strrev($num);
     $factor = 2;
@@ -19,6 +39,6 @@ function validar_rut(string $rut): bool {
     }
     $rest = 11 - ($sum % 11);
     $dv_calc = $rest == 11 ? '0' : ($rest == 10 ? 'K' : (string)$rest);
-    return $dv_calc === $dv;
+    return strtoupper($dv_calc) === $dv;
 }
 ?>

--- a/js/app.js
+++ b/js/app.js
@@ -3,7 +3,7 @@
 // Valida formato de RUT en el login
 function validarLogin() {
   const rut = document.getElementById('rut').value;
-  const regex = /^[0-9]+-[0-9Kk]$/;
+  const regex = /^\d{1,3}(?:\.\d{3})*-?[0-9Kk]$/;
   const errorEl = document.getElementById('rut-error');
   if (!regex.test(rut)) {
     errorEl.innerText = 'Formato de RUT inválido';

--- a/procesar_login.php
+++ b/procesar_login.php
@@ -1,9 +1,10 @@
 <?php
 session_start();
 include 'db.php';  // tu conexión a MySQL
+require_once 'includes/rut_validator.php';
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
-    $rut   = trim($_POST['rut']);
+    $rut   = limpiar_rut(trim($_POST['rut']));
     $clave = $_POST['clave'];
 
     // 1) Prepara y ejecuta la consulta solo por rut

--- a/usuarios.php
+++ b/usuarios.php
@@ -2,6 +2,7 @@
 // usuarios.php
 require_once 'includes/auth.php'; require_login();
 require_once 'includes/db.php';
+require_once 'includes/rut_validator.php';
 
 // Asegurar tabla de permisos
 $conn->query("CREATE TABLE IF NOT EXISTS user_permissions (
@@ -18,7 +19,7 @@ $modules = ['inventario','comparar','mi_usuario'];
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
   if (isset($_POST['create'])) {
     // Crear usuario
-    $rut   = trim($_POST['rut']);
+    $rut   = limpiar_rut(trim($_POST['rut']));
     $hash  = password_hash($_POST['clave'], PASSWORD_DEFAULT);
     $nom   = $conn->real_escape_string($_POST['nombre']);
     $ape   = $conn->real_escape_string($_POST['apellido']);


### PR DESCRIPTION
## Summary
- clean RUT values and add formatter/validator helpers
- sanitize input RUT in auth helper
- accept RUT with or without punctuation in login form
- normalize RUT when creating users and log in

## Testing
- `php -l includes/rut_validator.php`
- `php -l includes/auth.php`
- `php -l usuarios.php`
- `php -l cuenta01.php`
- `php -l procesar_login.php`


------
https://chatgpt.com/codex/tasks/task_e_68701613ea988326aa094b99f32a9cdc